### PR TITLE
Add missing color mapping for board fields

### DIFF
--- a/code Sandro/templates/board.html
+++ b/code Sandro/templates/board.html
@@ -256,9 +256,23 @@
     <div class="board">
       {# Mapping für deutsche Farbnamen zu CSS #}
       {% set farbmap = {
-        'gelb': 'yellow', 'rot': 'red', 'blau': 'blue', 'orange': 'orange',
-        'schwarz': 'black', 'lila': 'purple', 'gold': 'gold', 'grün': 'green',
-        'pink': 'pink', 'cyan': 'cyan', 'weiß': 'white'
+        'gelb': 'yellow',
+        'rot': 'red',
+        'blau': 'blue',
+        'orange': 'orange',
+        'schwarz': 'black',
+        'lila': 'purple',
+        'gold': 'gold',
+        'gruen': 'green',
+        'grün': 'green',
+        'pink': 'pink',
+        'cyan': 'cyan',
+        'weiss': 'white',
+        'weiß': 'white',
+        'braun': '#964B00',
+        'hellblau': '#ADD8E6',
+        'dunkelgrau': '#A9A9A9',
+        'rainbow': 'linear-gradient(45deg, red, orange, yellow, green, blue, indigo, violet)'
       } %}
       {# Die 40 Koordinaten für die äußeren Felder #}
       {% set koords = [
@@ -278,7 +292,7 @@
             {% set feldinfo = felder_infos[feld_idx] %}
             {% set css_farbe = farbmap.get(feldinfo.farbe|lower, feldinfo.farbe|lower if feldinfo.farbe else 'green') %}
             <div class="feld"
-              style="background-color: {{ css_farbe }};
+              style="background: {{ css_farbe }};
                      border: 2px solid black; cursor:pointer;"
               data-feld-index="{{ feld_idx }}">
               {{ feldinfo.name }}


### PR DESCRIPTION
## Summary
- update color mapping for game board fields to include all colors
- handle gradient style for rainbow fields

## Testing
- `pip install flask mysql-connector-python`
- `python 'code Sandro/game.py'` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68501a2cef408329929d288f163f4583