### PR TITLE
Refactor and polish Saufmonopoly

### DIFF
--- a/code Sandro/templates/board.html
+++ b/code Sandro/templates/board.html
@@ -14,7 +14,7 @@
       align-items: center;
       justify-content: center;
       min-height: 100vh;
-      background-color: #f4f4f4;
+      background: linear-gradient(180deg, #f4f4f4 0%, #e0e0e0 100%);
     }
 
     h2 {
@@ -41,8 +41,8 @@
     }
 
     .feld {
-      background-color: green;
-      border: 1px solid black;
+      background-color: #2e7d32;
+      border: 1px solid #000;
       display: flex;
       justify-content: center;
       align-items: center;


### PR DESCRIPTION
## Summary
- refactor `game.py` to use context managed DB access
- support environment based DB configuration
- tweak board styling

## Testing
- `python3 -m py_compile 'code Sandro/game.py'`

------
https://chatgpt.com/codex/tasks/task_e_68501b5a1bfc8329a15b8f34b84f9c88