### PR TITLE
Fix dice logic and property ownership

### DIFF
--- a/code Sandro/game.py
+++ b/code Sandro/game.py
@@ -195,16 +195,15 @@ def feld_aktion():
     aktiver = pending_popup["spieler"]  # Aktiver Spieler
     felder_infos = lade_felder_infos()  # Holt Felderinfos
     feld = felder_infos[board_index]  # Das aktuelle Feld
-    # feld_id = feld["feld_id"]  # Datenbank-ID des Feldes (NICHT MEHR NUTZEN)
-    feld_name = feld["name"]  # Name des Feldes (eindeutig)
+    feld_id = feld["feld_id"]  # Eindeutige ID des Feldes
 
     if aktion == "kaufen":
         spielername = session["spieler"][aktiver]  # Name des aktiven Spielers
         with db_cursor() as cursor:
             cursor.execute(
-                "UPDATE spielfelder SET besitzer=%s WHERE name=%s",
-                (spielername, feld_name),
-            )  # Setzt den Besitzer in der DB anhand des Namens
+                "UPDATE spielfelder SET besitzer=%s WHERE feld_id=%s",
+                (spielername, feld_id),
+            )  # Setzt den Besitzer in der DB anhand der ID
         schlucke = parse_schlucke(feld.get("kaufpreis"))  # Holt die Schlucke für den Kauf
         session["konto"][aktiver] += schlucke  # Addiert Schlucke zum Konto
         session["pending_popup"] = None  # Popup schließen

--- a/code Sandro/static/script.js
+++ b/code Sandro/static/script.js
@@ -1,39 +1,8 @@
 function wuerfeln() {
     const btn = document.getElementById('wuerfelnBtn');
     if (btn) btn.disabled = true;
-
-    let count = 0;
-    const max = 13;
-    const w1 = document.getElementById('w1');
-    const w2 = document.getElementById('w2');
-    const popup = document.getElementById('wurf-popup');
-    const popupText = document.getElementById('wurf-popup-text');
-    const popupOk = document.getElementById('wurf-popup-ok');
-
-    let wurf1 = 1, wurf2 = 1;
-    popup.style.display = 'none';
-    popupOk.style.display = 'none';
-
-    const anim = setInterval(() => {
-        wurf1 = Math.floor(Math.random()*6)+1;
-        wurf2 = Math.floor(Math.random()*6)+1;
-        w1.src = `/static/dice/${wurf1}.png`;
-        w2.src = `/static/dice/${wurf2}.png`;
-        count++;
-        if (count >= max) {
-            clearInterval(anim);
-            // Zeige NUR das kleine Popup mit Text und OK (KEINE Würfelbilder im Popup!)
-            popup.style.display = 'block';
-            popupText.textContent = `${window.aktiverSpieler} hat ${wurf1 + wurf2} gewürfelt!`;
-            popupOk.style.display = '';
-            popupOk.onclick = function() {
-                popup.style.display = 'none';
-                // Sende POST an /board um den Zug abzuschließen
-                const form = document.getElementById('wuerfelform');
-                if (form) form.submit();
-            };
-        }
-    }, 80);
+    const form = document.getElementById('wuerfelform');
+    if (form) form.submit();
     return false;
 }
 

--- a/code Sandro/templates/board.html
+++ b/code Sandro/templates/board.html
@@ -532,15 +532,17 @@
         let w1 = document.getElementById('anim-w1');
         let w2 = document.getElementById('anim-w2');
         let count = 0, max = 13;
-        let wurf = [1,1];
         let anim = setInterval(() => {
-          wurf = [Math.floor(Math.random()*6)+1, Math.floor(Math.random()*6)+1];
-          w1.src = `/static/dice/${wurf[0]}.png`;
-          w2.src = `/static/dice/${wurf[1]}.png`;
+          let r1 = Math.floor(Math.random()*6)+1;
+          let r2 = Math.floor(Math.random()*6)+1;
+          w1.src = `/static/dice/${r1}.png`;
+          w2.src = `/static/dice/${r2}.png`;
           count++;
           if (count >= max) {
             clearInterval(anim);
-            document.getElementById('wurf-modal-text').textContent = "{{ spieler[aktiver] }} hat gewürfelt!";
+            w1.src = `/static/dice/${window.wurf[0]}.png`;
+            w2.src = `/static/dice/${window.wurf[1]}.png`;
+            document.getElementById('wurf-modal-text').textContent = `${window.aktiverSpieler} hat ${window.wurf[0] + window.wurf[1]} gewürfelt!`;
             document.getElementById('wurf-bestätigen-btn').style.display = '';
             document.getElementById('wurf-bestätigen-btn').onclick = function() {
               fetch(window.location.pathname, {method:"POST"}).then(() => location.reload());


### PR DESCRIPTION
## Summary
- ensure bought property updates the correct database entry via `feld_id`
- simplify `wuerfeln()` to directly submit the form
- animate dice using server-provided results so movement matches the roll

## Testing
- `python3 -m py_compile 'code Sandro/game.py'`

------
https://chatgpt.com/codex/tasks/task_e_68502a833a848329b5dc75c40ce97e4e