### PR TITLE
Fix dice animation, add debug logs

### DIFF
--- a/code Sandro/game.py
+++ b/code Sandro/game.py
@@ -102,6 +102,9 @@ def spiel():
             würfel1 = random.randint(1, 6)  # Erster Würfel
             würfel2 = random.randint(1, 6)  # Zweiter Würfel
             summe = würfel1 + würfel2  # Summe der Würfel
+            print(
+                f"[DEBUG] {session['spieler'][aktiver]} würfelt {würfel1} + {würfel2} = {summe}"
+            )
             session["wurf"] = [würfel1, würfel2]  # Speichert den Wurf
             session["warte_auf_wurf"] = False  # Nicht mehr warten
             return redirect("/board")  # Seite neu laden
@@ -129,6 +132,9 @@ def spiel():
             summe = wurf[0] + wurf[1]  # Summe der Würfel
             aktuelle_pos = session["positionen"][aktiver]  # Aktuelle Position
             neue_pos = (aktuelle_pos + summe) % len(felder_infos)  # Neue Position nach dem Zug
+            print(
+                f"[DEBUG] {session['spieler'][aktiver]} zieht {summe} Felder von {aktuelle_pos} auf {neue_pos}"
+            )
             session["positionen"][aktiver] = neue_pos  # Speichert neue Position
             session["gesamt"][aktiver] += summe  # Addiert zur Gesamtzahl
             session["pending_popup"] = {
@@ -199,6 +205,12 @@ def feld_aktion():
 
     if aktion == "kaufen":
         spielername = session["spieler"][aktiver]  # Name des aktiven Spielers
+        print(
+            f"[DEBUG] {spielername} möchte Feld {feld_id} ({feld['name']}) vom Typ {feld['typ']} kaufen"
+        )
+        if feld["typ"] != "Straße":
+            print("[DEBUG] Kauf abgelehnt - kein Straßenfeld")
+            return jsonify({"ok": False, "msg": "Nur Straßen können gekauft werden."})
         with db_cursor() as cursor:
             cursor.execute(
                 "UPDATE spielfelder SET besitzer=%s WHERE feld_id=%s",

--- a/code Sandro/templates/board.html
+++ b/code Sandro/templates/board.html
@@ -527,10 +527,13 @@
         };
       {% elif zeige_wurf_popup %}
         // 2. Würfelanimation und Wurf-Popup
-        document.getElementById('wurf-modal').style.display = 'block';
-        document.getElementById('wurf-modal-text').textContent = "{{ spieler[aktiver] }} würfelt...";
-        let w1 = document.getElementById('anim-w1');
-        let w2 = document.getElementById('anim-w2');
+        const popup = document.getElementById('wurf-popup');
+        const popupText = document.getElementById('wurf-popup-text');
+        const okBtn = document.getElementById('wurf-popup-ok');
+        popup.style.display = 'block';
+        popupText.textContent = "{{ spieler[aktiver] }} würfelt...";
+        let w1 = document.getElementById('w1');
+        let w2 = document.getElementById('w2');
         let count = 0, max = 13;
         let anim = setInterval(() => {
           let r1 = Math.floor(Math.random()*6)+1;
@@ -542,10 +545,10 @@
             clearInterval(anim);
             w1.src = `/static/dice/${window.wurf[0]}.png`;
             w2.src = `/static/dice/${window.wurf[1]}.png`;
-            document.getElementById('wurf-modal-text').textContent = `${window.aktiverSpieler} hat ${window.wurf[0] + window.wurf[1]} gewürfelt!`;
-            document.getElementById('wurf-bestätigen-btn').style.display = '';
-            document.getElementById('wurf-bestätigen-btn').onclick = function() {
-              fetch(window.location.pathname, {method:"POST"}).then(() => location.reload());
+            popupText.textContent = `${window.aktiverSpieler} hat ${window.wurf[0] + window.wurf[1]} gewürfelt!`;
+            okBtn.style.display = '';
+            okBtn.onclick = function() {
+              fetch(window.location.pathname, {method:'POST'}).then(() => location.reload());
             };
           }
         }, 80);


### PR DESCRIPTION
## Summary
- implement dice animation using existing popup
- log dice rolls and moves server-side
- validate purchase type and log debug message

## Testing
- `python -m py_compile 'code Sandro/game.py'`

------
https://chatgpt.com/codex/tasks/task_e_685072e4b3c48329b122d57ad5d92aea